### PR TITLE
UI tweaks

### DIFF
--- a/webpackjs/components/MicromobilityData/index.js
+++ b/webpackjs/components/MicromobilityData/index.js
@@ -228,11 +228,15 @@ class MicromobilityData extends Component {
       dateQuery = event;
     }
     // Set data is loaded to false to render loading screen
-    // Set viewDataBy to null to clear month or date range selector
     this.setState({
       dataIsLoaded: false,
-      viewDataBy: null,
     });
+    // If date range was selected, set viewDataBy to null to clear selector
+    if (this.state.viewDataBy === "range") {
+      this.setState({
+        viewDataBy: null,
+      })
+    };
     this.runQueries(dateQuery, displayDateRangeType);
   }
 


### PR DESCRIPTION
I made a minor change to the UI that I think will make the app a little more efficient for people who want to compare several months in succession. Rather than having the user go back and click "select by month" before being able to select another month, the month selector dropdown remains available until the user chooses a different way of selecting the data (time range, etc.)

I just wanted to get this functionality running in time for the demo on Thursday. Thanks!

Fixes #299