### PR TITLE
fixed publisher log styling issues

### DIFF
--- a/components/css/publisher.css
+++ b/components/css/publisher.css
@@ -18,6 +18,21 @@
     color: black;
 }
 
+#modal_table_wrapper {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.modal-dialog {
+  max-width: 100%;
+}
+
+@media screen and (min-width: 600px) {
+  .modal-dialog {
+    max-width: 75%;
+  }
+}
+
 .modal-lg {
-    max-width: 1000px !important;
+    max-width: 100%;
 }


### PR DESCRIPTION
Fixes #265 

Removes duplicative vertical scrolling bar and ensures content doesn't overflow from modal div. Also adds media query to make modal fill smaller screens (<600 px wide).

<img width="1280" alt="Screen Shot 2019-10-11 at 2 19 39 PM" src="https://user-images.githubusercontent.com/35410637/66678483-a22e3280-ec31-11e9-8dc9-272d9aa451f8.png">
